### PR TITLE
Fix ip falsely detected when reading domain name (issue 2)

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -413,7 +413,7 @@ public class DomainNameReader {
           if (isAllHexSoFar && !CharUtils.isHex(curr)) {
             _numeric = false;
           }
-          //if its not numeric, remember that; excluded x/X for hex ip addresses.
+          //if its not numeric, remember that;
           if (!isAllHexSoFar && !CharUtils.isNumeric(curr)) {
             _numeric = false;
           }

--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -320,12 +320,15 @@ public class DomainNameReader {
 
     //while not done and not end of string keep reading.
     boolean done = false;
-    boolean isAllHexSoFar = (_current == null || _current.equals("")) &&
-      _reader.canReadChars(3) &&
+
+    //If this is the first domain part, check if it's ip address in is hexa
+    //similar to what is done on 'readCurrent' method
+    boolean isAllHexSoFar = (_current == null || _current.equals(""))
+      && _reader.canReadChars(3) &&
       ("0x".equalsIgnoreCase(_reader.peek(2)));
 
     if (isAllHexSoFar) {
-      //append hexa radix symbol characters
+      //Append hexa radix symbol characters (0x)
       _buffer.append(_reader.read());
       _buffer.append(_reader.read());
       _currentLabelLength += 2;

--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -320,7 +320,8 @@ public class DomainNameReader {
 
     //while not done and not end of string keep reading.
     boolean done = false;
-    boolean isAllHexSoFar = _reader.canReadChars(3) &&
+    boolean isAllHexSoFar = (_current == null || _current.equals("")) &&
+      _reader.canReadChars(3) &&
       ("0x".equalsIgnoreCase(_reader.peek(2)));
 
     if (isAllHexSoFar) {

--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -320,6 +320,17 @@ public class DomainNameReader {
 
     //while not done and not end of string keep reading.
     boolean done = false;
+    boolean isAllHexSoFar = _reader.canReadChars(3) &&
+      ("0x".equalsIgnoreCase(_reader.peek(2)));
+
+    if (isAllHexSoFar) {
+      //append hexa radix symbol characters
+      _buffer.append(_reader.read());
+      _buffer.append(_reader.read());
+      _currentLabelLength += 2;
+      _topLevelLength = _currentLabelLength;
+    }
+
     while (!done && !_reader.eof()) {
       char curr = _reader.read();
 
@@ -399,8 +410,11 @@ public class DomainNameReader {
           _reader.goBack();
           done = true;
         } else {
+          if (isAllHexSoFar && !CharUtils.isHex(curr)) {
+            _numeric = false;
+          }
           //if its not numeric, remember that; excluded x/X for hex ip addresses.
-          if (curr != 'x' && curr != 'X' && !CharUtils.isNumeric(curr)) {
+          if (!isAllHexSoFar && !CharUtils.isNumeric(curr)) {
             _numeric = false;
           }
 

--- a/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
@@ -82,7 +82,9 @@ public class TestNormalizedUrl {
         {"https://www.securesite.com/", "https://www.securesite.com/"},
         {"http://host.com/ab%23cd", "http://host.com/ab%23cd"},
         {"http://host.com//twoslashes?more//slashes", "http://host.com/twoslashes?more//slashes"},
-        {"http://go.co/a/b/../c", "http://go.co/a/c"}
+        {"http://go.co/a/b/../c", "http://go.co/a/c"},
+        {"http://0xb02067cd/", "http://176.32.103.205/"},
+        {"http://www.0xb02067cd/", "http://www.0xb02067cd/"},
     };
   }
 

--- a/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
@@ -83,7 +83,7 @@ public class TestNormalizedUrl {
         {"http://host.com/ab%23cd", "http://host.com/ab%23cd"},
         {"http://host.com//twoslashes?more//slashes", "http://host.com/twoslashes?more//slashes"},
         {"http://go.co/a/b/../c", "http://go.co/a/c"},
-        {"http://0xb02067cd/", "http://176.32.103.205/"},
+        {"http://big.big.boss@0xb02067cd/", "http://big.big.boss@176.32.103.205/"},
         {"http://www.0xb02067cd/", "http://www.0xb02067cd/"},
     };
   }

--- a/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestNormalizedUrl.java
@@ -85,6 +85,7 @@ public class TestNormalizedUrl {
         {"http://go.co/a/b/../c", "http://go.co/a/c"},
         {"http://big.big.boss@0xb02067cd/", "http://big.big.boss@176.32.103.205/"},
         {"http://www.0xb02067cd/", "http://www.0xb02067cd/"},
+        {"http://012.0xb02067cd/", "http://012.0xb02067cd/"}
     };
   }
 

--- a/url-detector/src/test/java/com/linkedin/urls/TestUrl.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestUrl.java
@@ -29,7 +29,9 @@ public class TestUrl {
         {"lalal:@www.gogo.com", "www.gogo.com", "/", "lalal", ""},
         {"nono:boo@[::1]", "[::1]", "/", "nono", "boo"},
         {"nono:boo@yahoo.com/@1234", "yahoo.com", "/@1234", "nono", "boo"},
-        {"big.big.boss@google.com", "google.com", "/", "big.big.boss", ""}
+        {"big.big.boss@google.com", "google.com", "/", "big.big.boss", ""},
+        {"big.big.boss@013.xxx", "013.xxx", "/", "big.big.boss", ""},
+        {"big.big.boss@0xb02067cz", "0xb02067cz", "/", "big.big.boss", ""},
     };
   }
 
@@ -117,7 +119,8 @@ public class TestUrl {
         {"fbeoo:@boop.com/dhdeh/@1234?aj=r", "boop.com", "http://fbeoo@boop.com/dhdeh/@1234?aj=r"},
         {"bloop:@noooo.com/doop/@1234", "noooo.com", "http://bloop@noooo.com/doop/@1234"},
         {"bah.com/lala/@1234/@dfd@df?@dsf#ono", "bah.com", "http://bah.com/lala/@1234/@dfd@df?@dsf#ono"},
-        {"https://dewd:dood@www.google.com:20/?why=is&this=test#?@Sdsf", "www.google.com", "https://dewd:dood@www.google.com:20/?why=is&this=test#?@Sdsf"}
+        {"https://dewd:dood@www.google.com:20/?why=is&this=test#?@Sdsf", "www.google.com", "https://dewd:dood@www.google.com:20/?why=is&this=test#?@Sdsf"},
+        {"http://013.xxx/","013.xxx", "http://013.xxx/"}
     };
   }
 


### PR DESCRIPTION
Should fix issue  #2

Root cause:
When domain contains only numbers and had 'x' character like ```http://013.xxx```, it was considered as ip address in hexa.
The fix is to better identify ip addresses in a way that such scenarios will not be falsely detected as ips anymore.