### PR TITLE
Add support for absolute positioning to know where the URL was

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/Url.java
+++ b/url-detector/src/main/java/com/linkedin/urls/Url.java
@@ -92,6 +92,10 @@ public class Url {
     return getFullUrlWithoutFragment() + StringUtils.defaultString(getFragment());
   }
 
+  public int getAbsoluteIndex() {
+    return _urlMarker.getAbsoluteIndex();
+  }
+
   /**
    *
    * @return Formats the url to: [scheme]://[username]:[password]@[host]:[port]/[path]?[query]

--- a/url-detector/src/main/java/com/linkedin/urls/Url.java
+++ b/url-detector/src/main/java/com/linkedin/urls/Url.java
@@ -92,6 +92,12 @@ public class Url {
     return getFullUrlWithoutFragment() + StringUtils.defaultString(getFragment());
   }
 
+  /**
+   * Get the position of URL in the original string. You can then retrieve URL by substring'ing original
+   * text. This can be useful for obtaining context where URL appeared.
+   *
+   * @return Index of the first character of URL in original string.
+   */
   public int getAbsoluteIndex() {
     return _urlMarker.getAbsoluteIndex();
   }

--- a/url-detector/src/main/java/com/linkedin/urls/UrlMarker.java
+++ b/url-detector/src/main/java/com/linkedin/urls/UrlMarker.java
@@ -12,6 +12,7 @@ package com.linkedin.urls;
 public class UrlMarker {
 
   private String _originalUrl;
+  private int _absoluteIndex = -1;
   private int _schemeIndex = -1;
   private int _usernamePasswordIndex = -1;
   private int _hostIndex = -1;
@@ -33,6 +34,14 @@ public class UrlMarker {
 
   public String getOriginalUrl() {
     return _originalUrl;
+  }
+
+  public int getAbsoluteIndex() {
+    return _absoluteIndex;
+  }
+
+  public void setAbsoluteIndex(int absoluteIndex) {
+    this._absoluteIndex = absoluteIndex;
   }
 
   public void setIndex(UrlPart urlPart, int index) {

--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -88,6 +88,10 @@ public class DomainNameReader {
      */
     ValidDomainName,
     /**
+     * The domain name is found to be valid, but is positioned one step behind of current position.
+     */
+    OffsetValidDomainName,
+    /**
      * Finished reading, next step should be to read the fragment.
      */
     ReadFragment,
@@ -320,6 +324,7 @@ public class DomainNameReader {
 
     //while not done and not end of string keep reading.
     boolean done = false;
+    boolean lastValid = false;
 
     //If this is the first domain part, check if it's ip address in is hexa
     //similar to what is done on 'readCurrent' method
@@ -411,8 +416,8 @@ public class DomainNameReader {
         //Valid domain name character. Either a-z, A-Z, 0-9, -, or international character
         if (_seenCompleteBracketSet) {
           //covers case of [fe80::]www.google.com
-          _reader.goBack();
           done = true;
+          lastValid = true;
         } else {
           if (isAllHexSoFar && !CharUtils.isHex(curr)) {
             _numeric = false;
@@ -432,8 +437,8 @@ public class DomainNameReader {
         _numeric = false;
         _buffer.append(curr);
       } else if (curr == '[' && _seenCompleteBracketSet) { //Case where [::][ ...
-        _reader.goBack();
         done = true;
+        lastValid = true;
       } else if (curr == '%' && _reader.canReadChars(2) && CharUtils.isHex(_reader.peekChar(0))
           && CharUtils.isHex(_reader.peekChar(1))) {
         //append to the states.
@@ -451,8 +456,16 @@ public class DomainNameReader {
       }
     }
 
+    if (lastValid) {
+      _reader.goBack();
+    }
+
     //Check the domain name to make sure its ok.
-    return checkDomainNameValid(ReaderNextState.ValidDomainName, null);
+    ReaderNextState nextState = done && !lastValid
+      ? ReaderNextState.OffsetValidDomainName
+      : ReaderNextState.ValidDomainName;
+
+    return checkDomainNameValid(nextState, null);
   }
 
   /**

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -106,9 +106,15 @@ public class UrlDetector {
    */
   public enum ReadEndState {
     /**
-     * The current url is valid.
+     * The current url is valid and is positioned exactly at the end of buffer
      */
     ValidUrl,
+
+    /**
+     * The current url is valid and is positioned one character behind the end of buffer
+     */
+    OffsetValidUrl,
+
     /**
      * The current url is invalid.
      */
@@ -551,6 +557,8 @@ public class UrlDetector {
     switch (state) {
       case ValidDomainName:
         return readEnd(ReadEndState.ValidUrl);
+      case OffsetValidDomainName:
+        return readEnd(ReadEndState.OffsetValidUrl);
       case ReadFragment:
         return readFragment();
       case ReadPath:
@@ -580,7 +588,7 @@ public class UrlDetector {
 
       //if it's the end or space, then a valid url was read.
       if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
-        return readEnd(ReadEndState.ValidUrl);
+        return readEnd(ReadEndState.OffsetValidUrl);
       } else {
         //otherwise keep appending.
         _buffer.append(curr);
@@ -606,7 +614,7 @@ public class UrlDetector {
         return readFragment();
       } else if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
         //end of query string
-        return readEnd(ReadEndState.ValidUrl);
+        return readEnd(ReadEndState.OffsetValidUrl);
       } else { //all else add to buffer.
         _buffer.append(curr);
       }
@@ -650,7 +658,7 @@ public class UrlDetector {
           _buffer.delete(_buffer.length() - 1, _buffer.length());
         }
         _currentUrlMarker.unsetIndex(UrlPart.PORT);
-        return readEnd(ReadEndState.ValidUrl);
+        return readEnd(portLen == 1 ? ReadEndState.OffsetValidUrl : ReadEndState.ValidUrl);
       } else {
         //this is a valid character in the port string.
         _buffer.append(curr);
@@ -673,7 +681,7 @@ public class UrlDetector {
 
       if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
         //if end of state and we got here, then the url is valid.
-        return readEnd(ReadEndState.ValidUrl);
+        return readEnd(ReadEndState.OffsetValidUrl);
       }
 
       //append the char
@@ -700,7 +708,7 @@ public class UrlDetector {
    */
   private boolean readEnd(ReadEndState state) {
     //if the url is valid and greater then 0
-    if (state == ReadEndState.ValidUrl && _buffer.length() > 0) {
+    if (state != ReadEndState.InvalidUrl && _buffer.length() > 0) {
       //get the last character. if its a quote, cut it off.
       int len = _buffer.length();
       if (_quoteStart && _buffer.charAt(len - 1) == '\"') {
@@ -709,6 +717,10 @@ public class UrlDetector {
 
       //Add the url to the list of good urls.
       if (_buffer.length() > 0) {
+        int position = Math.max(_reader.getPosition(), 0);
+        if (state == ReadEndState.OffsetValidUrl) position--;
+
+        _currentUrlMarker.setAbsoluteIndex(Math.max(0, position - len));
         _currentUrlMarker.setOriginalUrl(_buffer.toString());
         _urlList.add(_currentUrlMarker.createUrl());
       }

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -692,6 +692,11 @@ public class TestUriDetection {
     String[] foundArray = new String[found.size()];
     for (int i = 0; i < foundArray.length; i++) {
       foundArray[i] = found.get(i).getOriginalUrl();
+
+      // Test that positions gets annotated correctly: we can retrieve same URL by substring() from the input:
+      int absIndex = found.get(i).getAbsoluteIndex();
+      String urlSubstr = text.substring(absIndex, absIndex + foundArray[i].length());
+      Assert.assertEquals(urlSubstr, foundArray[i], "Substring URL does not match: indexing is broken");
     }
 
     Assert.assertEqualsNoOrder(foundArray, expected);


### PR DESCRIPTION
Sometimes you need not only URL itself, but also a position of that URL in source string.

This PR implements position annotations: you can use `getAbsoluteIndex()` to retrieve the offset from URL.

Unit tests were updated with index correctness checks. All existing test samples pass these indexing tests.