### PR TITLE
UrlDetectorOptions composition

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,34 @@ For example, the following code will find the url `linkedin.com`
     }
 ```
 
+### URL normalization and domain name conversion into its ASCII form for DNS lookup (including emojis)
+There are three main standards for converting [internationalized domain names (IDNA)](
+https://en.wikipedia.org/wiki/Internationalized_domain_name) into their ASCII forms:
+IDNA 2003, IDNA2008, and [UTS #46](http://www.unicode.org/reports/tr46/).
+
+As of May 2020, major web browsers employ UTS #46. This is a sort of more lenient,
+tradeoff standard between IDNA2003 and IDNA2008, that tries to accommodate both IDNA versions.
+However, this is not completely possible 
+(see [comparison table](http://www.unicode.org/reports/tr46/#Table_IDNA_Comparisons)).
+For this reason, the UTS #46 algorithm has several 
+[processing flags](http://www.unicode.org/reports/tr46/#Processing). 
+
+Example:
+```java
+    Url url = Url.create("https://i❤.ws/");
+    System.out.println("Normalized URL: " + url.normalize());
+```
+
+Optionally, UTS #46 Ascii [normalization options](
+(https://unicode-org.github.io/icu-docs/apidoc/released/icu4j/com/ibm/icu/text/IDNA.html#getUTS46Instance-int-))
+can be set. By default, we use `IDNA.NONTRANSITIONAL_TO_ASCII`.
+
+```java
+    import com.ibm.icu.text.IDNA;
+    HostNormalizer.setUts46Options(IDNA.NONTRANSITIONAL_TO_ASCII);
+```
+
+
 ### Quote Matching and HTML
 Depending on your input string, you may want to handle certain characters in a special way. For example if you are
 parsing HTML, you probably want to break out of things like quotes and brackets. For example, if your input looks like
@@ -78,6 +106,19 @@ To use the latest release, add the following dependency to your pom.xml:
     </dependency>
 ```
 
+The icu4j library is optional, given its size. Add it in you pom.xml as follows.
+
+```xml
+    <dependency>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <version>67.1</version>
+    </dependency>
+```
+
+If icu4j is not loaded, we fall back to `java.net.IDN.toASCII(host, IDN.ALLOW_UNASSIGNED)`,
+which only supports IDNA2003.
+
 ---
 ## About:
 
@@ -99,6 +140,11 @@ This library was written by the security team and Linkedin when other options di
 * http://commons.apache.org/proper/commons-lang/
 * Copyright © 2001-2014 The Apache Software Foundation
 * License: Apache 2.0
+
+### Optional, Unicode Icu4j: com.ibm.icu:icu4j:67.1
+* http://site.icu-project.org/home
+* Copyright © 1991-2020 Unicode, Inc. All rights reserved.
+* License: http://www.unicode.org/copyright.html#License
 
 ---
 ## License

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ subprojects {
     dependencies {
       testCompile spec.external.testng
       compile spec.external.'commonsLang'
+      compileOnly spec.external.'icu4j'
+      testCompileOnly spec.external.'icu4j'
     }
 
     test {

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -4,7 +4,8 @@ project.ext.spec = [
     "product": [],
     "external": [
         "testng": "org.testng:testng:6.1.1",
-        "commonsLang": "org.apache.commons:commons-lang3:3.1"
+        "commonsLang": "org.apache.commons:commons-lang3:3.1",
+        "icu4j": "com.ibm.icu:icu4j:67.1",
     ]
 ]
 

--- a/url-detector/pom.xml
+++ b/url-detector/pom.xml
@@ -40,6 +40,12 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.3.1</version>
     </dependency>
+    <dependency>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <version>67.1</version>
+        <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/url-detector/src/main/java/com/linkedin/urls/Url.java
+++ b/url-detector/src/main/java/com/linkedin/urls/Url.java
@@ -79,6 +79,15 @@ public class Url {
     return new NormalizedUrl(_urlMarker);
   }
 
+  /**
+   * True if the url has a valid top level domain (or is an ip address).
+   */
+  public boolean hasValidTopLevelDomain() {
+    List<Url> urls =
+      new UrlDetector(getHost(), UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN).detect();
+    return !urls.isEmpty();
+  }
+
   @Override
   public String toString() {
     return this.getFullUrl();

--- a/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/DomainNameReader.java
@@ -525,13 +525,14 @@ public class DomainNameReader {
       String topLevelStart = _buffer.substring(topStart, topStart + Math.min(4, _buffer.length() - topStart));
 
       //There is no size restriction if the top level domain is international (starts with "xn--")
-      valid =
-          ((!topLevelStart.equalsIgnoreCase("xn--") &&
-            (_topLevelLength < MIN_TOP_LEVEL_DOMAIN || _topLevelLength > MAX_TOP_LEVEL_DOMAIN)) ||
-            !_options.hasFlag(UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN) ||
-            _validTopLevelDomains.contains(
-              // full top level domain
-              _buffer.substring(topStart, topStart + _buffer.length() - topStart).toLowerCase()));
+      boolean sizeRestrictionCheck = topLevelStart.equalsIgnoreCase("xn--")
+        || (_topLevelLength >= MIN_TOP_LEVEL_DOMAIN && _topLevelLength <= MAX_TOP_LEVEL_DOMAIN);
+
+      boolean singleLevelCheck = (_options.hasFlag(UrlDetectorOptions.ALLOW_SINGLE_LEVEL_DOMAIN) && _dots == 0);
+      boolean validTopLevelCheck = !_options.hasFlag(UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN)
+        || _validTopLevelDomains.contains(_buffer.substring(topStart, topStart + _buffer.length() - topStart).toLowerCase());
+
+      valid = sizeRestrictionCheck && (singleLevelCheck || validTopLevelCheck);
     }
 
     if (valid) {

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -12,6 +12,8 @@ package com.linkedin.urls.detection;
 import com.linkedin.urls.Url;
 import com.linkedin.urls.UrlMarker;
 import com.linkedin.urls.UrlPart;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -123,6 +125,14 @@ public class UrlDetector {
   public UrlDetector(String content, UrlDetectorOptions options) {
     _reader = new InputTextReader(content);
     _options = options;
+    if (_options.hasFlag(UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN) &&
+      ! DomainNameReader.validTopLevelDomainsAreSet()) {
+      try {
+        DomainNameReader.refreshTopLevelDomainsFromIANA();
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
   }
 
   /**

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
@@ -12,72 +12,97 @@ package com.linkedin.urls.detection;
 /**
  * The options to use when detecting urls. This enum is used as a bit mask to be able to set multiple options at once.
  */
-public enum UrlDetectorOptions {
+public class UrlDetectorOptions {
+
   /**
    * Default options, no special checks.
    */
-  Default(0),
+  public static UrlDetectorOptions Default = new UrlDetectorOptions(0);
 
   /**
    * Matches quotes in the beginning and end of string.
    * If a string starts with a quote, then the ending quote will be eliminated. For example,
    * "http://linkedin.com" will pull out just 'http://linkedin.com' instead of 'http://linkedin.com"'
    */
-  QUOTE_MATCH(1), // 00000001
+  public static UrlDetectorOptions QUOTE_MATCH = new UrlDetectorOptions(1); // 00000001
 
   /**
    * Matches single quotes in the beginning and end of a string.
    */
-  SINGLE_QUOTE_MATCH(2), // 00000010
+  public static UrlDetectorOptions SINGLE_QUOTE_MATCH = new UrlDetectorOptions(2); // 00000010
 
   /**
    * Matches brackets and closes on the second one.
    * Same as quote matching but works for brackets such as (), {}, [].
    */
-  BRACKET_MATCH(4), // 000000100
+  public static UrlDetectorOptions BRACKET_MATCH = new UrlDetectorOptions(4); // 000000100
 
   /**
    * Checks for bracket characters and more importantly quotes to start and end strings.
    */
-  JSON(5), //00000101
+  public static UrlDetectorOptions JSON = new UrlDetectorOptions(5); //00000101
 
   /**
    * Checks JSON format or but also looks for a single quote.
    */
-  JAVASCRIPT(7), //00000111
+  public static UrlDetectorOptions JAVASCRIPT = new UrlDetectorOptions(7); //00000111
 
   /**
    * Checks for xml characters and uses them as ending characters as well as quotes.
    * This also includes quote_matching.
    */
-  XML(9), //00001001
+  public static UrlDetectorOptions XML = new UrlDetectorOptions(9); //00001001
 
   /**
    * Checks all of the rules besides brackets. This is XML but also can contain javascript.
    */
-  HTML(27), //00011011
+  public static UrlDetectorOptions HTML = new UrlDetectorOptions(27); //00011011
 
   /**
    * Checks for single level domains as well. Ex: go/, http://localhost
    */
-  ALLOW_SINGLE_LEVEL_DOMAIN(32), //00100000
+  public static UrlDetectorOptions ALLOW_SINGLE_LEVEL_DOMAIN = new UrlDetectorOptions(32); //00100000
 
   /**
    * Validates top level domains against IANA list
    * https://data.iana.org/TLD/tlds-alpha-by-domain.txt
    */
-  VALIDATE_TOP_LEVEL_DOMAIN(64); //01000000
+  public static UrlDetectorOptions VALIDATE_TOP_LEVEL_DOMAIN = new UrlDetectorOptions(64); //01000000
 
+  /**
+   * Compose two or more options, e.g. HTML and VALIDATE_TOP_LEVEL_DOMAIN.
+   * ALLOW_SINGLE_LEVEL_DOMAIN can only be mixed with VALIDATE_TOP_LEVEL_DOMAIN.
+   * @param options Two or more UrlDetectorOptions
+   * @return A new UrlDetectorOptions as the bitwise or of the options.
+   */
+  public static UrlDetectorOptions compose(UrlDetectorOptions... options) {
+    int composition = 0;
+    boolean formattingOptionPresent = false;
+    boolean allowSingleLevelDomainOptionPresent = false;
+
+    for (UrlDetectorOptions value : options) {
+      int option = value.getValue();
+
+      if (option < ALLOW_SINGLE_LEVEL_DOMAIN.getValue()) formattingOptionPresent = true;
+      if (option == ALLOW_SINGLE_LEVEL_DOMAIN.getValue()) allowSingleLevelDomainOptionPresent = true;
+      if (formattingOptionPresent && allowSingleLevelDomainOptionPresent)
+        throw new IllegalArgumentException(
+          "ALLOW_SINGLE_LEVEL_DOMAIN cannot be mixed with formatting options (e.g. HTML)");
+
+      composition |= option;
+    };
+    return new UrlDetectorOptions(composition);
+  }
   /**
    * The numeric value.
    */
-  private int _value;
+  private final int _value;
 
   /**
    * Creates a new Options enum
    * @param value The numeric value of the enum
    */
-  UrlDetectorOptions(int value) {
+  private UrlDetectorOptions(int value) {
     this._value = value;
   }
 

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
@@ -60,7 +60,13 @@ public enum UrlDetectorOptions {
   /**
    * Checks for single level domains as well. Ex: go/, http://localhost
    */
-  ALLOW_SINGLE_LEVEL_DOMAIN(32); //00100000
+  ALLOW_SINGLE_LEVEL_DOMAIN(32), //00100000
+
+  /**
+   * Validates top level domains against IANA list
+   * https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+   */
+  VALIDATE_TOP_LEVEL_DOMAIN(64); //01000000
 
   /**
    * The numeric value.

--- a/url-detector/src/test/java/com/linkedin/urls/TestHostNormalizer.java
+++ b/url-detector/src/test/java/com/linkedin/urls/TestHostNormalizer.java
@@ -82,7 +82,8 @@ public class TestHostNormalizer {
     return new Object[][] {
       {"☀♁♧.com", "xn--k3h6hoe.com"},
       {"🐩🤠🖊🍩🏳🐯🕶🐋.🍕💩.ws", "xn--gj8huimcrf6a45n5dx91a.xn--vi8hiv.ws"},
-      {"goȪgle.ga", "xn--gogle-jdc.ga"}
+      {"goȪgle.ga", "xn--gogle-jdc.ga"},
+      {"www.rößner.de", "www.xn--rner-vna1l.de"}
     };
   }
 

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -712,6 +712,20 @@ public class TestUriDetection {
     Assert.assertTrue(Url.create("http://192.168.1.1").hasValidTopLevelDomain());
   }
 
+  @Test
+  public void optionComposition() {
+    runTest(
+      "<script type=\"text/javascript\">var a = 'http://www.abc.nonExistingTLD', b=\"www.def.com\"</script><a href=\"http://www.google.com\">google.com</a>",
+      UrlDetectorOptions.compose(UrlDetectorOptions.HTML, UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN),
+      "http://www.google.com", "www.def.com", "google.com");
+
+    runTest(
+      "http://localhost hello.nonExistingTLD",
+      UrlDetectorOptions.compose(UrlDetectorOptions.ALLOW_SINGLE_LEVEL_DOMAIN, UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN),
+      "http://localhost"
+      );
+  }
+
   @DataProvider
   private Object[][] getUrlsForSchemaDetectionInHtml() {
     String domain = "linkedin.com";

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -11,6 +11,7 @@ package com.linkedin.urls.detection;
 
 import com.linkedin.urls.Url;
 
+import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
@@ -697,7 +698,17 @@ public class TestUriDetection {
     // kills loop in UrlDetector.readDefault()  
     runTest(" :u ", UrlDetectorOptions.ALLOW_SINGLE_LEVEL_DOMAIN);
   }
-  
+
+  @Test
+  public void validTld() throws MalformedURLException {
+    runTest("hello.nonExistingTLD", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN);
+    runTest("hello.com", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN, "hello.com");
+    runTest("http://192.168.1.1", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN, "http://192.168.1.1");
+    Assert.assertFalse(Url.create("hello.nonExistingTLD").hasValidTopLevelDomain());
+    Assert.assertTrue(Url.create("hello.barcelona").hasValidTopLevelDomain());
+    Assert.assertTrue(Url.create("http://192.168.1.1").hasValidTopLevelDomain());
+  }
+
   @DataProvider
   private Object[][] getUrlsForSchemaDetectionInHtml() {
     String domain = "linkedin.com";

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -704,6 +704,9 @@ public class TestUriDetection {
     runTest("hello.nonExistingTLD", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN);
     runTest("hello.com", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN, "hello.com");
     runTest("http://192.168.1.1", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN, "http://192.168.1.1");
+    runTest("hello.o", UrlDetectorOptions.VALIDATE_TOP_LEVEL_DOMAIN);
+    runTest("hello.o", UrlDetectorOptions.Default);
+    runTest("http://localhost", UrlDetectorOptions.ALLOW_SINGLE_LEVEL_DOMAIN, "http://localhost");
     Assert.assertFalse(Url.create("hello.nonExistingTLD").hasValidTopLevelDomain());
     Assert.assertTrue(Url.create("hello.barcelona").hasValidTopLevelDomain());
     Assert.assertTrue(Url.create("http://192.168.1.1").hasValidTopLevelDomain());


### PR DESCRIPTION
Allow composition of `UrlDetectorOptions` through `UrlDetectorOptions.compose` to allow more than one detection option at the same time. Useful to compose formatting options (e.g. `HTML | VALIDATE_TOP_LEVEL_DOMAIN` or `VALIDATE_TOP_LEVEL_DOMAIN | ALLOW_SINGLE_LEVEL_DOMAIN`). 

While `UrlDetectorOptions` is now a `class` instead of an `enum`, no changes were made to the syntax of the API nor to the rest of the code (except to allow the composition of `VALIDATE_TOP_LEVEL_DOMAIN | ALLOW_SINGLE_LEVEL_DOMAIN`, in a piece of code added by me in a previous PR). Besides, given that option values are bitwise or'ed, no invalid values can be generated.