### PR TITLE
Revert "Add support for absolute positioning to know where the URL was"

### DIFF
--- a/url-detector/src/main/java/com/linkedin/urls/Url.java
+++ b/url-detector/src/main/java/com/linkedin/urls/Url.java
@@ -93,16 +93,6 @@ public class Url {
   }
 
   /**
-   * Get the position of URL in the original string. You can then retrieve URL by substring'ing original
-   * text. This can be useful for obtaining context where URL appeared.
-   *
-   * @return Index of the first character of URL in original string.
-   */
-  public int getAbsoluteIndex() {
-    return _urlMarker.getAbsoluteIndex();
-  }
-
-  /**
    *
    * @return Formats the url to: [scheme]://[username]:[password]@[host]:[port]/[path]?[query]
    */

--- a/url-detector/src/main/java/com/linkedin/urls/UrlMarker.java
+++ b/url-detector/src/main/java/com/linkedin/urls/UrlMarker.java
@@ -12,7 +12,6 @@ package com.linkedin.urls;
 public class UrlMarker {
 
   private String _originalUrl;
-  private int _absoluteIndex = -1;
   private int _schemeIndex = -1;
   private int _usernamePasswordIndex = -1;
   private int _hostIndex = -1;
@@ -34,14 +33,6 @@ public class UrlMarker {
 
   public String getOriginalUrl() {
     return _originalUrl;
-  }
-
-  public int getAbsoluteIndex() {
-    return _absoluteIndex;
-  }
-
-  public void setAbsoluteIndex(int absoluteIndex) {
-    this._absoluteIndex = absoluteIndex;
   }
 
   public void setIndex(UrlPart urlPart, int index) {

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -106,15 +106,9 @@ public class UrlDetector {
    */
   public enum ReadEndState {
     /**
-     * The current url is valid and is positioned exactly at the end of buffer
+     * The current url is valid.
      */
     ValidUrl,
-
-    /**
-     * The current url is valid and is positioned one character behind the end of buffer
-     */
-    OffsetValidUrl,
-
     /**
      * The current url is invalid.
      */
@@ -572,8 +566,6 @@ public class UrlDetector {
     switch (state) {
       case ValidDomainName:
         return readEnd(ReadEndState.ValidUrl);
-      case OffsetValidDomainName:
-        return readEnd(ReadEndState.OffsetValidUrl);
       case ReadFragment:
         return readFragment();
       case ReadPath:
@@ -603,7 +595,7 @@ public class UrlDetector {
 
       //if it's the end or space, then a valid url was read.
       if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
-        return readEnd(ReadEndState.OffsetValidUrl);
+        return readEnd(ReadEndState.ValidUrl);
       } else {
         //otherwise keep appending.
         _buffer.append(curr);
@@ -629,7 +621,7 @@ public class UrlDetector {
         return readFragment();
       } else if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
         //end of query string
-        return readEnd(ReadEndState.OffsetValidUrl);
+        return readEnd(ReadEndState.ValidUrl);
       } else { //all else add to buffer.
         _buffer.append(curr);
       }
@@ -673,7 +665,7 @@ public class UrlDetector {
           _buffer.delete(_buffer.length() - 1, _buffer.length());
         }
         _currentUrlMarker.unsetIndex(UrlPart.PORT);
-        return readEnd(portLen == 1 ? ReadEndState.OffsetValidUrl : ReadEndState.ValidUrl);
+        return readEnd(ReadEndState.ValidUrl);
       } else {
         //this is a valid character in the port string.
         _buffer.append(curr);
@@ -696,7 +688,7 @@ public class UrlDetector {
 
       if (curr == ' ' || checkMatchingCharacter(curr) != CharacterMatch.CharacterNotMatched) {
         //if end of state and we got here, then the url is valid.
-        return readEnd(ReadEndState.OffsetValidUrl);
+        return readEnd(ReadEndState.ValidUrl);
       }
 
       //append the char
@@ -723,7 +715,7 @@ public class UrlDetector {
    */
   private boolean readEnd(ReadEndState state) {
     //if the url is valid and greater then 0
-    if (state != ReadEndState.InvalidUrl && _buffer.length() > 0) {
+    if (state == ReadEndState.ValidUrl && _buffer.length() > 0) {
       //get the last character. if its a quote, cut it off.
       int len = _buffer.length();
       if (_quoteStart && _buffer.charAt(len - 1) == '\"') {
@@ -732,10 +724,6 @@ public class UrlDetector {
 
       //Add the url to the list of good urls.
       if (_buffer.length() > 0) {
-        int position = Math.max(_reader.getPosition(), 0);
-        if (state == ReadEndState.OffsetValidUrl) position--;
-
-        _currentUrlMarker.setAbsoluteIndex(Math.max(0, position - len));
         _currentUrlMarker.setOriginalUrl(_buffer.toString());
         _urlList.add(_currentUrlMarker.createUrl());
       }

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -738,11 +738,6 @@ public class TestUriDetection {
     String[] foundArray = new String[found.size()];
     for (int i = 0; i < foundArray.length; i++) {
       foundArray[i] = found.get(i).getOriginalUrl();
-
-      // Test that positions gets annotated correctly: we can retrieve same URL by substring() from the input:
-      int absIndex = found.get(i).getAbsoluteIndex();
-      String urlSubstr = text.substring(absIndex, absIndex + foundArray[i].length());
-      Assert.assertEquals(urlSubstr, foundArray[i], "Substring URL does not match: indexing is broken");
     }
 
     Assert.assertEqualsNoOrder(foundArray, expected);


### PR DESCRIPTION
Reverts URL-Detector/URL-Detector#7

I had to revert as there were test errors:

`Failed tests:   testColonEmbededurl(com.linkedin.urls.detection.TestUriDetection): String index out of range: -1            
  testIPv6Colons(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1                     
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIPv6Ipv4AddressesWithSpaces(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1    
  testIpv6LongUrlWithInheritedScheme(com.linkedin.urls.detection.TestUriDetection): Arrays do not have the same size:2 != 1 
  testIssue12(com.linkedin.urls.detection.TestUriDetection): String index out of range: -1                                  `

@makkarpov can you take a look?  I tried merging to the develop branch.