### PR TITLE
Add flag to allow custom url schemes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 .gradle
 .idea
 *.iml
+build/
+local.properties

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetector.java
@@ -458,14 +458,19 @@ public class UrlDetector {
       if (curr == '/') {
         _buffer.append(curr);
         if (numSlashes == 1) {
-          //return only if its an approved protocol. This can be expanded to allow others
-          int schemeStartIndex = findValidSchemeStartIndex(_buffer.toString());
+          int schemeStartIndex = 0;
+          if (!_options.hasFlag(UrlDetectorOptions.ALLOW_ANY_SCHEME)) {
+            // Return only if its an approved protocol (or has an approved protocol as the suffix).
+            schemeStartIndex = findValidSchemeStartIndex(_buffer.toString());
+          }
           if (schemeStartIndex >= 0) {
             _buffer.delete(0, schemeStartIndex);
             _currentUrlMarker.setIndex(UrlPart.SCHEME, 0);
             return true;
           } else {
-            return false;
+            // TODO how do i consume the rest of this invalid url to ensure it doesn't get detected
+            // TODO with the default http scheme
+            return readEnd(ReadEndState.InvalidUrl);
           }
         }
         numSlashes++;

--- a/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
+++ b/url-detector/src/main/java/com/linkedin/urls/detection/UrlDetectorOptions.java
@@ -60,7 +60,12 @@ public enum UrlDetectorOptions {
   /**
    * Checks for single level domains as well. Ex: go/, http://localhost
    */
-  ALLOW_SINGLE_LEVEL_DOMAIN(32); //00100000
+  ALLOW_SINGLE_LEVEL_DOMAIN(32), //00100000
+
+  /**
+   * Allow custom url schemes. Ex: foo:://bar/taco
+   */
+  ALLOW_ANY_SCHEME(64); //01000000
 
   /**
    * The numeric value.

--- a/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
+++ b/url-detector/src/test/java/com/linkedin/urls/detection/TestUriDetection.java
@@ -712,6 +712,13 @@ public class TestUriDetection {
     runTest(text, UrlDetectorOptions.HTML, expected);
   }
 
+  @Test
+  public void testCustomScheme() {
+    runTest("this is a link: myscheme://foo", UrlDetectorOptions.Default);
+    runTest("this is a link: myscheme://www.google.com", UrlDetectorOptions.Default);
+    runTest("this is a link: myscheme://www.google.com", UrlDetectorOptions.ALLOW_ANY_SCHEME, "myscheme://www.google.com");
+  }
+
   private void runTest(String text, UrlDetectorOptions options, String... expected) {
     //do the detection
     UrlDetector parser = new UrlDetector(text, options);


### PR DESCRIPTION
Hi folks!  I'm using this library in an android app and I'd like to allow detection of URLs with custom schemes.  I've got this flag mostly working but I could use some help with the case where there's a custom scheme in front of an otherwise valid domain name.  